### PR TITLE
GitHub actions updates to include ARM64 build, test and release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
         value: ${{ jobs.build.outputs.version }}
 
 jobs:
-  build:
+  extract-version:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
@@ -24,6 +24,22 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Building version: ${VERSION}"
 
+  build:
+    needs: extract-version
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      version: ${{ needs.extract-version.outputs.version }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Configure CMake (GCC 12)
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release \
@@ -36,10 +52,10 @@ jobs:
       - name: Build Debian package
         run: |
           cp build/rmp-eval .
-          ./packaging/build_deb.sh ${{ steps.extract_version.outputs.version }}
+          ./packaging/build_deb.sh ${{ needs.extract-version.outputs.version }}
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rmp-eval-package
-          path: rmp-eval_${{ steps.extract_version.outputs.version }}_amd64.deb
+          name: rmp-eval-package-${{ matrix.arch }}
+          path: rmp-eval_${{ needs.extract-version.outputs.version }}_${{ matrix.arch }}.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
   workflow_call:
     outputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run every Monday at 6:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          queries: security-and-quality
+
+      - name: Configure CMake (GCC 12)
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_COMPILER=gcc-12 \
+                -DCMAKE_CXX_COMPILER=g++-12
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:cpp"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download package artifact
+      - name: Download amd64 package artifact
         uses: actions/download-artifact@v4
         with:
-          name: rmp-eval-package
+          name: rmp-eval-package-amd64
+          path: .
+
+      - name: Download arm64 package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rmp-eval-package-arm64
           path: .
 
       - name: Create GitHub Release
@@ -70,13 +76,14 @@ jobs:
         run: |
           VERSION="${{ needs.ci.outputs.version }}"
 
-          # Create release with the package
+          # Create release with both packages
           gh release create "${VERSION}" \
             --title "${VERSION}" \
             --generate-notes \
-            rmp-eval_${VERSION}_amd64.deb
+            rmp-eval_${VERSION}_amd64.deb \
+            rmp-eval_${VERSION}_arm64.deb
 
-          echo "::notice title=Release Complete::Successfully released version ${VERSION}"
+          echo "::notice title=Release Complete::Successfully released version ${VERSION} for amd64 and arm64"
 
       - name: Create Job Summary
         run: |
@@ -85,7 +92,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release Details" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: ${VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Package**: rmp-eval_${VERSION}_amd64.deb" >> $GITHUB_STEP_SUMMARY
+          echo "- **Packages**:" >> $GITHUB_STEP_SUMMARY
+          echo "  - rmp-eval_${VERSION}_amd64.deb" >> $GITHUB_STEP_SUMMARY
+          echo "  - rmp-eval_${VERSION}_arm64.deb" >> $GITHUB_STEP_SUMMARY
           echo "- **Release URL**: https://github.com/${{ github.repository }}/releases/tag/${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-22.04-arm
     steps:
       - name: Download package artifact
         uses: actions/download-artifact@v4
         with:
-          name: rmp-eval-package
+          name: rmp-eval-package-${{ matrix.arch }}
           path: .
 
       - name: Install package

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # rmp-eval
+
+[![CI](https://github.com/SRNemoto/rmp-eval/actions/workflows/ci.yml/badge.svg)](https://github.com/SRNemoto/rmp-eval/actions/workflows/ci.yml)
+[![Release](https://github.com/SRNemoto/rmp-eval/actions/workflows/release.yml/badge.svg)](https://github.com/SRNemoto/rmp-eval/actions/workflows/release.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rmp-eval
 
 [![CI](https://github.com/SRNemoto/rmp-eval/actions/workflows/ci.yml/badge.svg)](https://github.com/SRNemoto/rmp-eval/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/SRNemoto/rmp-eval/actions/workflows/codeql.yml/badge.svg)](https://github.com/SRNemoto/rmp-eval/actions/workflows/codeql.yml)
 [![Release](https://github.com/SRNemoto/rmp-eval/actions/workflows/release.yml/badge.svg)](https://github.com/SRNemoto/rmp-eval/actions/workflows/release.yml)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 # rmp-eval
-A simple utility to evaluate latencies on a Linux system and determine real-time capabilities.

--- a/include/version.h
+++ b/include/version.h
@@ -6,6 +6,6 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_MICRO 4
+#define VERSION_MICRO 1
 
 #endif // VERSION_H


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to support building, testing, and releasing packages for both `amd64` and `arm64` architectures. The workflows are refactored to use matrix builds, and release steps are updated to handle multiple package artifacts. Additionally, documentation and versioning are updated for clarity and accuracy.

**CI/CD pipeline improvements:**

* Refactored `.github/workflows/build.yml` to use separate `extract-version` and `build` jobs, with matrix strategy to build for both `amd64` and `arm64` architectures. Package artifact names now include the architecture. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L12-R12) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R27-R42) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L39-R61)
* Updated `.github/workflows/release.yml` to download and release both `amd64` and `arm64` package artifacts, and improved release summary to list both packages. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L61-R70) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L73-R86) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L88-R97)
* Modified `.github/workflows/test.yml` to test both architectures using a matrix strategy and updated artifact names accordingly.
* Enabled CI workflow triggers on push to `main` and pull requests for better coverage.

**Documentation and versioning:**

* Added CI and Release workflow badges to `README.md` for improved visibility of build status.
* Updated version in `include/version.h` from `0.0.4` to `0.0.1` to reflect the correct release version.