### PR TITLE
  Add --only-config option, document default values in --help, add FAQ to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,15 @@ RMP is designed to run all its threads on a single isolated CPU. This is the nor
 
 ### Should RMP be running during this test?
 
-**No.** Do not run rmp-eval while RMP/RMPNetwork is running. This tool is meant to evaluate your hardware **before** deploying RMP, not to test alongside it. Running both simultaneously would interfere with the timing measurements.
+No. Do not run rmp-eval while RMP/RMPNetwork is running. This tool is meant to evaluate your hardware **before** deploying RMP, not to test alongside it. Running both simultaneously would interfere with the timing measurements.
 
 ### How long should I run the test?
 
-We recommend running for at least **5-10 minutes** to capture various system states and potential latency spikes. Longer tests (30-60 minutes) can reveal issues that only occur under sustained load or periodic system activities. Press `Ctrl+C` to stop and view results.
+We recommend initially running for at least **5-10 minutes** to capture various system states and potential latency spikes. Longer tests (24+ hours) can reveal issues that only occur under sustained load or periodic system activities. Press `Ctrl+C` to stop and view results.
+
+### Should I test under load?
+
+Yes. To get a realistic assessment, run the test while your system is under typical load conditions expected during RMP operation.
 
 ### What do the latency categories/buckets mean?
 
@@ -198,25 +202,9 @@ Based on the RMP [PC hardware latency requirements.](https://support.roboticsys.
 
 For 1kHz (1000µs period), aim for all samples in "Great" category with max latency < 125µs. The buckets will scale proportionally for different target periods. 
 
-### The CPU frequency check shows a warning - is this a problem?
-
-The reported CPU frequency for isolated cores is **not always reliable** due to the difficulty of reading frequency values from fully isolated CPUs. Focus instead on ensuring:
-
-1. The CPU governor is set to "performance" (the tool checks this)
-2. Turbo/boost is disabled (the tool checks this)
-3. Your actual timing results are in the "Great" category
-
-Tools like `turbostat` (x64) can provide more accurate frequency readings if needed, but the timing measurements themselves are the definitive indicator of system performance.
-
 ### Some config checks failed - can I still use my system?
 
-It depends on which checks failed and the measured performance:
-
-- **Critical**: PREEMPT_RT, RT core isolation - these must pass
-- **Important**: CPU governor=performance, turbo disabled, deep C-states, IRQ affinity - fix these if possible
-- **Informational**: CPU frequency reading - not critical if timing results are good
-
-The timing results table is the ultimate test. If your latencies are consistently in "Great" range despite some config warnings, your system may still be suitable.
+The timing results table is the ultimate test. If your latencies are consistently in "Great" range (under load) despite some config warnings, your system is still suitable.
 
 ### Do I need a PREEMPT_RT kernel to run this tool?
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ sudo rmp-eval --nic enp2s0
 
 **Note:** The NIC must have an EtherCAT drive connected for this test.
 
+**Check system configuration only (no timing tests):**
+
+```bash
+sudo rmp-eval --only-config
+```
+
+This runs all configuration checks and exits without starting timing threads.
+
 Press `Ctrl+C` to stop the test and view final results.
 
 ## Example Output
@@ -121,6 +129,7 @@ Options:
 --receive-cpu, -rc       CPU core to use for the receiver thread
 --verbose, -v            Enable verbose output
 --no-config, -nc         Skip system configuration checks
+--only-config, -oc       Run system configuration checks only, then exit
 --bucket-width, -b       Bucket width in microseconds for counting occurrences.
 --help, -h               Show this help message
 --version                Show version information

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Based on the RMP [PC hardware latency requirements.](https://support.roboticsys.
 - **Bad** (< 1000µs): Inadequate for reliable operation
 - **Pathetic** (≥ 1000µs): Unacceptable, missed deadline
 
-For 1kHz (1000µs period), aim for all samples in "Great" category with max latency < 125µs.  The buckets will scale proportionally for different target periods. 
+For 1kHz (1000µs period), aim for all samples in "Great" category with max latency < 125µs. The buckets will scale proportionally for different target periods. 
 
 ### The CPU frequency check shows a warning - is this a problem?
 

--- a/README.md
+++ b/README.md
@@ -121,16 +121,17 @@ Columns:
 
 Options:
 --nic, -n                Network interface card name
---iterations, -i         Number of iterations
---send-sleep, -s         Send sleep duration in microseconds
---send-priority, -sp     Send thread priority
---receive-priority, -rp  Receive thread priority
---send-cpu, -sc          CPU core to use for the sender thread
---receive-cpu, -rc       CPU core to use for the receiver thread
+--iterations, -i         Number of iterations (default: infinite)
+--send-sleep, -s         Send sleep duration in microseconds (default: 1000)
+--send-priority, -sp     Send thread priority (default: 42)
+--receive-priority, -rp  Receive thread priority (default: 45)
+--send-cpu, -sc          CPU core to use for the sender thread (default: last core)
+--receive-cpu, -rc       CPU core to use for the receiver thread (default: last core)
 --verbose, -v            Enable verbose output
 --no-config, -nc         Skip system configuration checks
 --only-config, -oc       Run system configuration checks only, then exit
---bucket-width, -b       Bucket width in microseconds for counting occurrences.
+--bucket-width, -b       Bucket width in microseconds for counting occurrences (default:
+                         auto).
 --help, -h               Show this help message
 --version                Show version information
 ```

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ Options:
 --verbose, -v            Enable verbose output
 --no-config, -nc         Skip system configuration checks
 --only-config, -oc       Run system configuration checks only, then exit
---bucket-width, -b       Bucket width in microseconds for counting occurrences (default:
-                         auto).
+--bucket-width, -b       Bucket width in microseconds for counting occurrences (default: auto).
 --help, -h               Show this help message
 --version                Show version information
 ```
@@ -158,6 +157,85 @@ cmake --build build
 # Run
 sudo ./build/rmp-eval
 ```
+
+## FAQ
+
+### What are the Sender and Receiver threads?
+
+The **Sender** thread simulates the cyclic thread that sends EtherCAT frames at a fixed rate (default 1000µs/1kHz). The **Receiver** thread waits for and processes EtherCAT responses. These two threads are sufficient to identify worst-case latency in your system.
+
+When no NIC is specified, only the Sender thread runs (labeled "Cyclic") to test basic cyclic timing performance.
+
+### How does this relate to RMP's 8 threads?
+
+While RMP/RMPNetwork uses 8 threads in total for its full operation, this evaluation tool focuses on testing the **worst-case latency** of the critical cyclic timing path. The 2-thread test (sender/receiver) is designed to stress-test the timing characteristics that matter most for real-time performance.
+
+### Should both threads run on the same isolated CPU?
+
+**Yes.** Both the sender and receiver threads should run on the same isolated CPU (default behavior). This matches how RMP operates - all 8 of RMP's threads normally run on a single isolated CPU. You can verify/change this with `--send-cpu` and `--receive-cpu` options if needed, but keeping them on the same core is the recommended configuration.
+
+### Can RMP use multiple isolated CPUs?
+
+RMP is designed to run all its threads on a single isolated CPU. This is the normal and expected configuration for optimal real-time performance.
+
+### Should RMP be running during this test?
+
+**No.** Do not run rmp-eval while RMP/RMPNetwork is running. This tool is meant to evaluate your hardware **before** deploying RMP, not to test alongside it. Running both simultaneously would interfere with the timing measurements.
+
+### How long should I run the test?
+
+We recommend running for at least **5-10 minutes** to capture various system states and potential latency spikes. Longer tests (30-60 minutes) can reveal issues that only occur under sustained load or periodic system activities. Press `Ctrl+C` to stop and view results.
+
+### What do the latency categories/buckets mean?
+
+Based on the RMP [PC hardware latency requirements.](https://support.roboticsys.com/rmp/guide-pc-latency-jitter-bios.html)
+
+- **Great** (< 125µs): Excellent for 1kHz operation, meets RMP requirements
+- **Good** (< 250µs): Acceptable but approaching limits
+- **Poor** (< 500µs): Marginal, may cause issues under load
+- **Bad** (< 1000µs): Inadequate for reliable operation
+- **Pathetic** (≥ 1000µs): Unacceptable, missed deadline
+
+For 1kHz (1000µs period), aim for all samples in "Great" category with max latency < 125µs.  The buckets will scale proportionally for different target periods. 
+
+### The CPU frequency check shows a warning - is this a problem?
+
+The reported CPU frequency for isolated cores is **not always reliable** due to the difficulty of reading frequency values from fully isolated CPUs. Focus instead on ensuring:
+
+1. The CPU governor is set to "performance" (the tool checks this)
+2. Turbo/boost is disabled (the tool checks this)
+3. Your actual timing results are in the "Great" category
+
+Tools like `turbostat` (x64) can provide more accurate frequency readings if needed, but the timing measurements themselves are the definitive indicator of system performance.
+
+### Some config checks failed - can I still use my system?
+
+It depends on which checks failed and the measured performance:
+
+- **Critical**: PREEMPT_RT, RT core isolation - these must pass
+- **Important**: CPU governor=performance, turbo disabled, deep C-states, IRQ affinity - fix these if possible
+- **Informational**: CPU frequency reading - not critical if timing results are good
+
+The timing results table is the ultimate test. If your latencies are consistently in "Great" range despite some config warnings, your system may still be suitable.
+
+### Do I need a PREEMPT_RT kernel to run this tool?
+
+The tool will run on non-RT kernels, but **PREEMPT_RT is required for RMP** itself. This evaluation tool checks for PREEMPT_RT and will report if it's missing. If you're evaluating hardware for RMP deployment, install a PREEMPT_RT kernel first to get accurate results.
+
+### Why do I need an EtherCAT drive connected for NIC testing?
+
+The receiver thread waits for actual EtherCAT responses to measure round-trip timing. Without a connected drive, the receiver will timeout and the test will fail. If you only want to test cyclic timing without NIC hardware, omit the `--nic` parameter to run in cyclic-only mode.
+
+### Can I use this tool for non-RMP real-time applications?
+
+Yes! While designed for RMP evaluation, this tool is useful for testing any Linux real-time system that requires:
+
+- Sub-millisecond cyclic timing
+- Low-latency EtherCAT communication
+- Isolated CPU performance validation
+- PREEMPT_RT kernel verification
+
+Adjust `--send-sleep` to match your application's cycle time.
 
 ## License
 

--- a/include/version.h
+++ b/include/version.h
@@ -6,6 +6,6 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_MICRO 2
+#define VERSION_MICRO 3
 
 #endif // VERSION_H

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -424,6 +424,12 @@ int main(int argc, char* argv[])
       return 1;
     }
 
+    if (geteuid() != 0)
+    {
+      std::cerr << "Error: Not running as root. This may cause failures when accessing system configuration or opening raw sockets.\n";
+      return 1;
+    }
+
     if (!noConfig)
     {
       Evaluator::ReportSystemConfiguration(params.SendCpu, params.NicName);
@@ -433,12 +439,6 @@ int main(int argc, char* argv[])
     if (onlyConfig)
     {
       return 0;
-    }
-
-    if (geteuid() != 0)
-    {
-      std::cerr << "Error: Not running as root. This may cause failures when opening raw sockets or setting thread priorities.\n";
-      return 1;
     }
 
     if (mlockall(MCL_CURRENT | MCL_FUTURE) != 0)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -376,6 +376,7 @@ int main(int argc, char* argv[])
     params.ReceiveData = &receiveData;
 
     bool noConfig = false;
+    bool onlyConfig = false;
 
     std::atomic<bool> liveReport = true;
 
@@ -389,6 +390,7 @@ int main(int argc, char* argv[])
     Evaluator::AddArgument(arguments, {"--receive-cpu", "-rc"}, &params.ReceiveCpu, "CPU core to use for the receiver thread");
     Evaluator::AddArgument(arguments, {"--verbose", "-v"}, &params.IsVerbose, "Enable verbose output");
     Evaluator::AddArgument(arguments, {"--no-config", "-nc"}, &noConfig, "Skip system configuration checks");
+    Evaluator::AddArgument(arguments, {"--only-config", "-oc"}, &onlyConfig, "Run system configuration checks only, then exit");
     Evaluator::AddArgument(arguments, {"--bucket-width", "-b"}, &params.BucketWidth, "Bucket width in microseconds for counting occurrences.");
 
     bool showHelp = false;
@@ -415,9 +417,22 @@ int main(int argc, char* argv[])
       return 0;  // Exit after showing version
     }
 
+    // Validate that --no-config and --only-config are not used together
+    if (noConfig && onlyConfig)
+    {
+      std::cerr << "Error: --no-config and --only-config cannot be used together.\n";
+      return 1;
+    }
+
     if (!noConfig)
     {
       Evaluator::ReportSystemConfiguration(params.SendCpu, params.NicName);
+    }
+
+    // If --only-config is specified, exit after configuration checks
+    if (onlyConfig)
+    {
+      return 0;
     }
 
     if (geteuid() != 0)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -382,16 +382,16 @@ int main(int argc, char* argv[])
 
     std::vector<Evaluator::Argument> arguments;
     Evaluator::AddArgument(arguments, {"--nic", "-n"}, &params.NicName, "Network interface card name");
-    Evaluator::AddArgument(arguments, {"--iterations", "-i"}, &params.Iterations, "Number of iterations");
-    Evaluator::AddArgument(arguments, {"--send-sleep", "-s"}, &params.SendSleep, "Send sleep duration in microseconds");
-    Evaluator::AddArgument(arguments, {"--send-priority", "-sp"}, &params.SendPriority, "Send thread priority");
-    Evaluator::AddArgument(arguments, {"--receive-priority", "-rp"}, &params.ReceivePriority, "Receive thread priority");
-    Evaluator::AddArgument(arguments, {"--send-cpu", "-sc"}, &params.SendCpu, "CPU core to use for the sender thread");
-    Evaluator::AddArgument(arguments, {"--receive-cpu", "-rc"}, &params.ReceiveCpu, "CPU core to use for the receiver thread");
+    Evaluator::AddArgument(arguments, {"--iterations", "-i"}, &params.Iterations, "Number of iterations (default: infinite)");
+    Evaluator::AddArgument(arguments, {"--send-sleep", "-s"}, &params.SendSleep, "Send sleep duration in microseconds (default: " + std::to_string(DefaultSendSleepMicroseconds) + ")");
+    Evaluator::AddArgument(arguments, {"--send-priority", "-sp"}, &params.SendPriority, "Send thread priority (default: " + std::to_string(DefaultSendPriority) + ")");
+    Evaluator::AddArgument(arguments, {"--receive-priority", "-rp"}, &params.ReceivePriority, "Receive thread priority (default: " + std::to_string(DefaultReceivePriority) + ")");
+    Evaluator::AddArgument(arguments, {"--send-cpu", "-sc"}, &params.SendCpu, "CPU core to use for the sender thread (default: last core)");
+    Evaluator::AddArgument(arguments, {"--receive-cpu", "-rc"}, &params.ReceiveCpu, "CPU core to use for the receiver thread (default: last core)");
     Evaluator::AddArgument(arguments, {"--verbose", "-v"}, &params.IsVerbose, "Enable verbose output");
     Evaluator::AddArgument(arguments, {"--no-config", "-nc"}, &noConfig, "Skip system configuration checks");
     Evaluator::AddArgument(arguments, {"--only-config", "-oc"}, &onlyConfig, "Run system configuration checks only, then exit");
-    Evaluator::AddArgument(arguments, {"--bucket-width", "-b"}, &params.BucketWidth, "Bucket width in microseconds for counting occurrences.");
+    Evaluator::AddArgument(arguments, {"--bucket-width", "-b"}, &params.BucketWidth, "Bucket width in microseconds for counting occurrences (default: auto).");
 
     bool showHelp = false;
     Evaluator::AddArgument(arguments, {"--help", "-h"}, &showHelp, "Show this help message");


### PR DESCRIPTION
This pull request primarily improves usability and documentation for the `rmp-eval` tool, clarifies command-line options, and adds new functionality for configuration-only checks. The README has been expanded with a comprehensive FAQ and updated option descriptions, while the main program now supports a new `--only-config` mode and validates option combinations to prevent user error.

**Documentation improvements:**

* Expanded the `README.md` with a detailed FAQ section explaining the sender/receiver threads, recommended CPU configuration, latency categories, PREEMPT_RT requirements, and more, making it easier for users to understand and correctly use the tool.
* Updated command-line option descriptions in `README.md` to include default values and clarify the behavior of each option, including the new `--only-config` flag.
* Added usage instructions for the new configuration-only mode to the `README.md`.

**Command-line interface enhancements:**

* Added the `--only-config` (`-oc`) option to the argument parser in `source/main.cpp`, allowing users to run only system configuration checks without performing timing tests.
* Updated argument descriptions in `source/main.cpp` to include default values for greater clarity.

**Robustness and error handling:**

* Implemented validation in `source/main.cpp` to prevent using `--no-config` and `--only-config` together, displaying an error and exiting if both are specified. Also, the program now exits immediately after configuration checks when `--only-config` is used.

**Version update:**

* Bumped the micro version from 0.0.2 to 0.0.3 in `include/version.h` to reflect these feature and documentation improvements.