### PR TITLE
Add config check for kernel 6.17+ and prctl(PR_FUTEX_HASH)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -46,6 +46,7 @@ namespace Evaluator
     SmtSiblingIsolated,
     TimerMigration,
     AfXdpSupport,
+    FutexPrivateHash,
   };
   
   enum class Status

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -1180,12 +1180,18 @@ namespace Evaluator
       struct utsname unameInfo = {};
       std::string versionStr = "unknown";
       bool versionOk = false;
-      if (uname(&unameInfo) == 0)
+      if (uname(&unameInfo) != 0)
       {
-        versionStr = unameInfo.release;
-        if (auto kv = ParseKernelVersion(versionStr))
-          versionOk = KernelAtLeast(*kv, 6, 17);
+        return { Kind(), Status::Unknown, Name(),
+          "Expected kernel >= 6.17, but uname() failed: " + std::string(strerror(errno)) };
       }
+
+      versionStr = unameInfo.release;
+      if (auto kv = ParseKernelVersion(versionStr))
+        versionOk = KernelAtLeast(*kv, 6, 17);
+      else
+        return { Kind(), Status::Unknown, Name(),
+          "Cannot parse kernel version from uname: " + versionStr };
 
       // No point calling prctl on a kernel that predates the feature.
       if (!versionOk)
@@ -1199,7 +1205,7 @@ namespace Evaluator
       // but the kernel hasn't created the default 16 slots yet (on the first thread creation).
       // https://man7.org/linux/man-pages/man2/PR_FUTEX_HASH.2const.html
       if (ret >= 0)
-        return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded;" };
+        return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded" };
 
       static constexpr size_t BufferSize = 256;
       char buffer[BufferSize]{};

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -34,7 +34,7 @@
 
 // PR_FUTEX_HASH was added in Linux 6.17. Define if not yet in system headers.
 #ifndef PR_FUTEX_HASH
-#define PR_FUTEX_HASH          76
+#define PR_FUTEX_HASH          78
 #endif
 #ifndef PR_FUTEX_HASH_SET_SLOTS
 #define PR_FUTEX_HASH_SET_SLOTS  1
@@ -1185,18 +1185,23 @@ namespace Evaluator
       }
 
       // Probe the running kernel — this is the authoritative test.
-      int ret = prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS, 0, 0, 0);
-      if (ret == 0)
+      static constexpr int DefaultSlots = 16; // The default number of futex hash slots in the kernel as of 6.17
+      int ret = prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS, DefaultSlots, 0, 0);
+      if (ret >= 0) // prctl returns a nonnegative value on success.
         return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded (kernel " + versionStr + ")" };
+
 
       // prctl failed — provide context-aware diagnostics.
       if (!versionOk)
         return { Kind(), Status::Fail, Name(),
           "kernel " + versionStr + " < 6.17; private futex hash requires >= 6.17" };
 
-      return { Kind(), Status::Fail, Name(),
-        "kernel " + versionStr + " >= 6.17 but prctl(PR_FUTEX_HASH) failed (errno "
-        + std::to_string(errno) + "); CONFIG_FUTEX_PRIVATE_HASH may be disabled" };
+      static constexpr size_t BufferSize = 256;
+      char buffer[BufferSize]{};
+      std::snprintf(buffer, BufferSize,
+        "Kernel %s version >= 6.17, but prctl(PR_FUTEX_HASH) failed with errno %d: %s; CONFIG_FUTEX_PRIVATE_HASH may be disabled",
+        versionStr.c_str(), errno, strerror(errno));
+      return { Kind(), Status::Fail, Name(), std::string(buffer) };
     }
   };
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <arpa/inet.h>
+#include <charconv>
 #include <cerrno>
 #include <climits>
 #include <cmath>
@@ -27,8 +28,17 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>
+
+// PR_FUTEX_HASH was added in Linux 6.17. Define if not yet in system headers.
+#ifndef PR_FUTEX_HASH
+#define PR_FUTEX_HASH          76
+#endif
+#ifndef PR_FUTEX_HASH_SET_SLOTS
+#define PR_FUTEX_HASH_SET_SLOTS  1
+#endif
 #include <unistd.h>
 #include <vector>
 
@@ -43,6 +53,38 @@ namespace
   // Both indicate AF_XDP support is available on this kernel.
   constexpr std::string_view ConfigXdpSocketsBuiltin = "CONFIG_XDP_SOCKETS=y";
   constexpr std::string_view ConfigXdpSocketsModule  = "CONFIG_XDP_SOCKETS=m";
+  struct KernelVersion
+  {
+    int major{};
+    int minor{};
+    int patch{};
+  };
+
+  // Parse a kernel version string (e.g. "6.17.1-rt5") using std::from_chars.
+  // Only the leading "major.minor.patch" numeric portion is required;
+  // trailing suffixes like "-rt5" or "-generic" are ignored.
+  [[nodiscard]] std::optional<KernelVersion> ParseKernelVersion(std::string_view release)
+  {
+    KernelVersion version{};
+    const char* ptr   = release.data();
+    const char* end = ptr + release.size();
+
+    auto result = std::from_chars(ptr, end, version.major);
+    if (result.ec != std::errc{} || result.ptr == end || *result.ptr != '.') return std::nullopt;
+
+    result = std::from_chars(result.ptr + 1, end, version.minor);
+    if (result.ec != std::errc{} || result.ptr == end || *result.ptr != '.') return std::nullopt;
+
+    result = std::from_chars(result.ptr + 1, end, version.patch);
+    if (result.ec != std::errc{}) return std::nullopt;
+
+    return version;
+  }
+
+  [[nodiscard]] bool KernelAtLeast(const KernelVersion& version, int major, int minor)
+  {
+    return version.major > major || (version.major == major && version.minor >= minor);
+  }
 
   struct PipeGuard
   {
@@ -1122,6 +1164,42 @@ namespace Evaluator
     }
   };
 
+  class FutexPrivateHashCheck final : public ICheck
+  {
+  public:
+    [[nodiscard]] CheckKind Kind() const noexcept override { return CheckKind::FutexPrivateHash; }
+    [[nodiscard]] const std::string& Name() const noexcept override { static const std::string k = "Private futex hash table"; return k; }
+    [[nodiscard]] Domain GetDomain() const noexcept override { return Domain::System; }
+
+    [[nodiscard]] CheckResult Evaluate(const CheckContext&, const IDataSource&) const override
+    {
+      // Check kernel version first for a useful diagnostic message.
+      struct utsname unameInfo = {};
+      std::string versionStr = "unknown";
+      bool versionOk = false;
+      if (uname(&unameInfo) == 0)
+      {
+        versionStr = unameInfo.release;
+        if (auto version = ParseKernelVersion(versionStr))
+          versionOk = KernelAtLeast(*version, 6, 17);
+      }
+
+      // Probe the running kernel — this is the authoritative test.
+      int ret = prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS, 0, 0, 0);
+      if (ret == 0)
+        return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded (kernel " + versionStr + ")" };
+
+      // prctl failed — provide context-aware diagnostics.
+      if (!versionOk)
+        return { Kind(), Status::Fail, Name(),
+          "kernel " + versionStr + " < 6.17; private futex hash requires >= 6.17" };
+
+      return { Kind(), Status::Fail, Name(),
+        "kernel " + versionStr + " >= 6.17 but prctl(PR_FUTEX_HASH) failed (errno "
+        + std::to_string(errno) + "); CONFIG_FUTEX_PRIVATE_HASH may be disabled" };
+    }
+  };
+
   // Helper functions for system info
 
   std::string GetCpuInfo()
@@ -1377,6 +1455,7 @@ namespace Evaluator
     system_checks.emplace_back(std::make_unique<Evaluator::RtThrottlingCheck>());
     system_checks.emplace_back(std::make_unique<Evaluator::ClocksourceCheck>());
     system_checks.emplace_back(std::make_unique<Evaluator::AfXdpSupportCheck>());
+    system_checks.emplace_back(std::make_unique<Evaluator::FutexPrivateHashCheck>());
 
     for (const auto &check : system_checks)
     {

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -5,8 +5,8 @@
 
 #include <algorithm>
 #include <arpa/inet.h>
-#include <charconv>
 #include <cerrno>
+#include <charconv>
 #include <climits>
 #include <cmath>
 #include <cstdarg>
@@ -76,11 +76,13 @@ namespace
     if (result.ec != std::errc{} || result.ptr == end || *result.ptr != '.') return std::nullopt;
 
     result = std::from_chars(result.ptr + 1, end, version.minor);
-    if (result.ec != std::errc{} || result.ptr == end || *result.ptr != '.') return std::nullopt;
-
-    result = std::from_chars(result.ptr + 1, end, version.patch);
     if (result.ec != std::errc{}) return std::nullopt;
 
+    // Patch level is optional, still return if it's missing or fails to parse.
+    if (result.ptr < end && *result.ptr == '.')
+    {
+      result = std::from_chars(result.ptr + 1, end, version.patch);
+    }
     return version;
   }
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -39,6 +39,9 @@
 #ifndef PR_FUTEX_HASH_SET_SLOTS
 #define PR_FUTEX_HASH_SET_SLOTS  1
 #endif
+#ifndef PR_FUTEX_HASH_GET_SLOTS
+#define PR_FUTEX_HASH_GET_SLOTS  2
+#endif
 #include <unistd.h>
 #include <vector>
 
@@ -1173,33 +1176,35 @@ namespace Evaluator
 
     [[nodiscard]] CheckResult Evaluate(const CheckContext&, const IDataSource&) const override
     {
-      // Check kernel version first for a useful diagnostic message.
+      // Parse the running kernel version for diagnostics and gating.
       struct utsname unameInfo = {};
       std::string versionStr = "unknown";
       bool versionOk = false;
       if (uname(&unameInfo) == 0)
       {
         versionStr = unameInfo.release;
-        if (auto version = ParseKernelVersion(versionStr))
-          versionOk = KernelAtLeast(*version, 6, 17);
+        if (auto kv = ParseKernelVersion(versionStr))
+          versionOk = KernelAtLeast(*kv, 6, 17);
       }
 
-      // Probe the running kernel — this is the authoritative test.
-      static constexpr int DefaultSlots = 16; // The default number of futex hash slots in the kernel as of 6.17
-      int ret = prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_SET_SLOTS, DefaultSlots, 0, 0);
-      if (ret >= 0) // prctl returns a nonnegative value on success.
-        return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded (kernel " + versionStr + ")" };
-
-
-      // prctl failed — provide context-aware diagnostics.
+      // No point calling prctl on a kernel that predates the feature.
       if (!versionOk)
         return { Kind(), Status::Fail, Name(),
           "kernel " + versionStr + " < 6.17; private futex hash requires >= 6.17" };
 
+      // Probe the running kernel — this is the authoritative test.
+      // PR_FUTEX_HASH_GET_SLOTS is a read-only query with no side effects.
+      int ret = prctl(PR_FUTEX_HASH, PR_FUTEX_HASH_GET_SLOTS, 0, 0, 0);
+      // The return value may be 0, indicating the PR_FUTEX_HASH operation is valid
+      // but the kernel hasn't created the default 16 slots yet (on the first thread creation).
+      // https://man7.org/linux/man-pages/man2/PR_FUTEX_HASH.2const.html
+      if (ret >= 0)
+        return { Kind(), Status::Pass, Name(), "prctl(PR_FUTEX_HASH) succeeded;" };
+
       static constexpr size_t BufferSize = 256;
       char buffer[BufferSize]{};
       std::snprintf(buffer, BufferSize,
-        "Kernel %s version >= 6.17, but prctl(PR_FUTEX_HASH) failed with errno %d: %s; CONFIG_FUTEX_PRIVATE_HASH may be disabled",
+        "kernel %s >= 6.17 but prctl(PR_FUTEX_HASH) failed (errno %d: %s)",
         versionStr.c_str(), errno, strerror(errno));
       return { Kind(), Status::Fail, Name(), std::string(buffer) };
     }

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -1177,24 +1177,21 @@ namespace Evaluator
     {
       // Parse the running kernel version for diagnostics and gating.
       struct utsname unameInfo = {};
-      std::string versionStr = "unknown";
-      bool versionOk = false;
       if (uname(&unameInfo) != 0)
       {
         return { Kind(), Status::Unknown, Name(),
           "Expected kernel >= 6.17, but uname() failed: " + std::string(strerror(errno)) };
       }
 
-      versionStr = unameInfo.release;
+      std::string versionStr = unameInfo.release;
       static constexpr KernelVersion MinimumVersion{ 6, 17, 0 };
-      if (auto version = ParseKernelVersion(versionStr))
-        versionOk = *version >= MinimumVersion;
-      else
+      auto version = ParseKernelVersion(versionStr);
+      if (!version)
         return { Kind(), Status::Unknown, Name(),
           "Cannot parse kernel version from uname: " + versionStr };
 
       // No point calling prctl on a kernel that predates the feature.
-      if (!versionOk)
+      if (*version < MinimumVersion)
         return { Kind(), Status::Fail, Name(),
           "kernel " + versionStr + " < 6.17; private futex hash requires >= 6.17" };
 
@@ -1209,9 +1206,10 @@ namespace Evaluator
 
       static constexpr size_t BufferSize = 256;
       char buffer[BufferSize]{};
+      const auto errorCode = errno;
       std::snprintf(buffer, BufferSize,
         "kernel %s >= 6.17 but prctl(PR_FUTEX_HASH) failed (errno %d: %s)",
-        versionStr.c_str(), errno, strerror(errno));
+        versionStr.c_str(), errorCode, strerror(errorCode));
       return { Kind(), Status::Fail, Name(), std::string(buffer) };
     }
   };

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -61,6 +61,8 @@ namespace
     int major{};
     int minor{};
     int patch{};
+
+    auto operator<=>(const KernelVersion& other) const = default;
   };
 
   // Parse a kernel version string (e.g. "6.17.1-rt5") using std::from_chars.
@@ -84,11 +86,6 @@ namespace
       result = std::from_chars(result.ptr + 1, end, version.patch);
     }
     return version;
-  }
-
-  [[nodiscard]] bool KernelAtLeast(const KernelVersion& version, int major, int minor)
-  {
-    return version.major > major || (version.major == major && version.minor >= minor);
   }
 
   struct PipeGuard
@@ -1189,8 +1186,9 @@ namespace Evaluator
       }
 
       versionStr = unameInfo.release;
-      if (auto kv = ParseKernelVersion(versionStr))
-        versionOk = KernelAtLeast(*kv, 6, 17);
+      static constexpr KernelVersion MinimumVersion{ 6, 17, 0 };
+      if (auto version = ParseKernelVersion(versionStr))
+        versionOk = *version >= MinimumVersion;
       else
         return { Kind(), Status::Unknown, Name(),
           "Cannot parse kernel version from uname: " + versionStr };


### PR DESCRIPTION
Linux 6.17 added the feature to create a private futex hash table for each individual process by default. This reduces the probability that any real-time process that interacts with the futex subsystem will experience lock contention on a global futex bucket with any unrelated processes.

https://man7.org/linux/man-pages/man2/PR_FUTEX_HASH.2const.html

Assisted by: Claude Opus 4.6